### PR TITLE
Enable custom URLs for Okta issuer

### DIFF
--- a/okta.tf
+++ b/okta.tf
@@ -32,10 +32,10 @@ resource "okta_app_oauth" "vault" {
     name        = "groups"
     value       = "vault"
   }
-  login_mode = "SPEC"
-  login_scopes = ["openid","email","profile"]
-  hide_web = false
-  hide_ios = false
+  login_mode   = "SPEC"
+  login_scopes = ["openid", "email", "profile"]
+  hide_web     = false
+  hide_ios     = false
 }
 
 resource "okta_app_oauth_api_scope" "vault" {
@@ -58,7 +58,7 @@ resource "okta_auth_server" "vault" {
   audiences   = [var.okta_auth_audience]
   description = ""
   name        = "vault"
-  issuer_mode = "ORG_URL"
+  issuer_mode = var.okta_issue_mode
   status      = "ACTIVE"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,7 @@ variable "vault_addr" {
 variable "vault_namespace" {
   type        = string
   description = "namespace in which to mount the auth method"
-  default = ""
+  default     = ""
 }
 
 variable "okta_org_name" {
@@ -22,6 +22,12 @@ variable "okta_base_url" {
 variable "okta_base_url_full" {
   type        = string
   description = "Full URL of Okta login, usually instanceID.okta.com, ie https://dev-208447.okta.com"
+}
+
+variable "okta_issue_mode" {
+  type        = string
+  description = "Indicates whether the Okta Authorization Server uses the original Okta org domain URL or a custom domain URL as the issuer of ID token for this client. ORG_URL = foo.okta.com, CUSTOM_URL = custom domain"
+  default     = "ORG_URL"
 }
 
 variable "okta_api_token" {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1116529/148090956-04c17220-2f56-4e54-bb23-7c530ca16d18.png)

custom domains can be enabled with okta_issue_mode = CUSTOM_URL

(as long as you've done the steps within Okta itself to enable it. Admin dashboard > Customizations > Domain)


In my case, I'm using okta.lmhd.me, so I've also got:
* okta_org_name = okta
* okta_base_url = lmhd.me

However, I still have:
* okta_base_url_full = https://lmhd.okta.com
As this variable is used to define the scope of the API token (which Okta requires to be provided in this format)